### PR TITLE
Dump values in unique list

### DIFF
--- a/lib/litestack/litekd/unique_list.rb
+++ b/lib/litestack/litekd/unique_list.rb
@@ -3,16 +3,16 @@ module Litekd
 
     def push(member)
       conn.transaction do
-        conn.delete_composite_member_by_value(@key, member)
-        conn.rpush_composite_member(@key, member)
+        conn.delete_composite_member_by_value(@key, dump(member))
+        conn.rpush_composite_member(@key, dump(member))
         _after_change
       end
     end
     
     def lpush(member)
       conn.transaction do
-        conn.delete_composite_member_by_value(@key, member)
-        conn.lpush_composite_member(@key, member)
+        conn.delete_composite_member_by_value(@key, dump(member))
+        conn.lpush_composite_member(@key, dump(member))
         _after_change
       end
     end


### PR DESCRIPTION
Currently adding integer values to UniqueList creates them as integers, but removal looking for them as strings, which leads to broken functionality.